### PR TITLE
:bug: Add ReadonlyArray extension types

### DIFF
--- a/src/collections.ts
+++ b/src/collections.ts
@@ -77,7 +77,7 @@ declare global {
     firstNotNullishOf<O>(
       selector: (item: T) => O | undefined | null
     ): NonNullable<O> | undefined
-    groupBy(selector: (el: T) => string): Record<string, T[]>
+    groupBy<Key extends string>(selector: (el: T) => Key): Record<Key, T[]>
     intersect(...arrays: (readonly T[])[]): T[]
     mapNotNullish<O>(transformer: (el: T) => O): NonNullable<O>[]
     maxBy(selector: (el: T) => string): T | undefined
@@ -132,7 +132,7 @@ declare global {
     firstNotNullishOf<O>(
       selector: (item: T) => O | undefined | null
     ): NonNullable<O> | undefined
-    groupBy(selector: (el: T) => string): Record<string, T[]>
+    groupBy<Key extends string>(selector: (el: T) => Key): Record<Key, T[]>
     intersect(...arrays: (readonly T[])[]): T[]
     mapNotNullish<O>(transformer: (el: T) => O): NonNullable<O>[]
     maxBy(selector: (el: T) => string): T | undefined


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.0--canary.4.cf6c584cf791d1d75cbff1da38cf2cb363b45c15.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/ext@1.2.0--canary.4.cf6c584cf791d1d75cbff1da38cf2cb363b45c15.0
  # or 
  yarn add @opencreek/ext@1.2.0--canary.4.cf6c584cf791d1d75cbff1da38cf2cb363b45c15.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
