### PR TITLE
:sparkles: Add mapValues for objects

### DIFF
--- a/src/objects.ts
+++ b/src/objects.ts
@@ -44,7 +44,7 @@ declare global {
     ): T | undefined
 
     mapValues<T, Key extends keyof T, O>(
-      thiz: Readonly<Record<Key, T>>,
+      this: Readonly<Record<Key, T>>,
       transformer: (value: T) => O
     ): Record<Key, O>
   }

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -1,3 +1,4 @@
+import { mapValues } from "@opencreek/deno-std-collections"
 import { extendProtoype } from "./extendPrototype"
 
 function mapThis<T, V>(
@@ -26,6 +27,7 @@ function takeUnless<T>(
 extendProtoype(Object, takeIf, "takeIf")
 extendProtoype(Object, takeUnless, "takeUnless")
 extendProtoype(Object, mapThis, "mapThis")
+extendProtoype(Object, mapValues, "mapValues")
 
 declare global {
   interface Object {
@@ -40,5 +42,7 @@ declare global {
       this: NonNullable<T>,
       predicate: (thiz: NonNullable<T>) => boolean
     ): T | undefined
+
+    mapValues<T, Key extends keyof T, O>(thiz: Readonly<Record<Key, T>>, transformer: (value: T) => O): Record<Key, O>;
   }
 }

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -43,6 +43,9 @@ declare global {
       predicate: (thiz: NonNullable<T>) => boolean
     ): T | undefined
 
-    mapValues<T, Key extends keyof T, O>(thiz: Readonly<Record<Key, T>>, transformer: (value: T) => O): Record<Key, O>;
+    mapValues<T, Key extends keyof T, O>(
+      thiz: Readonly<Record<Key, T>>,
+      transformer: (value: T) => O
+    ): Record<Key, O>
   }
 }

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -1,5 +1,5 @@
 import { mapValues } from "@opencreek/deno-std-collections"
-import { extendProtoype } from "./extendPrototype"
+import { apply, extendProtoype } from "./extendPrototype"
 
 function mapThis<T, V>(
   this: NonNullable<T>,
@@ -27,7 +27,7 @@ function takeUnless<T>(
 extendProtoype(Object, takeIf, "takeIf")
 extendProtoype(Object, takeUnless, "takeUnless")
 extendProtoype(Object, mapThis, "mapThis")
-extendProtoype(Object, mapValues, "mapValues")
+extendProtoype(Object, apply(mapValues), "mapValues")
 
 declare global {
   interface Object {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.0--canary.6.d6a0297abbe9a837776b5abd12836ca8535f9814.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/ext@1.4.0--canary.6.d6a0297abbe9a837776b5abd12836ca8535f9814.0
  # or 
  yarn add @opencreek/ext@1.4.0--canary.6.d6a0297abbe9a837776b5abd12836ca8535f9814.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
