### PR TITLE
:bug: Add missing overloads in Array interface

### DIFF
--- a/src/collections.ts
+++ b/src/collections.ts
@@ -93,6 +93,8 @@ declare global {
     minBy(selector: (el: T) => Date): T | undefined
     minOf(selector: (el: T) => bigint): bigint | undefined
     minOf(selector: (el: T) => number): number | undefined
+    minOf(selector: (el: T) => string): string | undefined
+    minOf(selector: (el: T) => Date): Date | undefined
     minWith(comparator: (a: T, b: T) => number): T | undefined
     partition(predicate: (el: T) => boolean): [T[], T[]]
     permutations(): T[][]


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.1--canary.8.9991fa6ae2f62b263a3e10e4f31b94bd751c1d03.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/ext@1.5.1--canary.8.9991fa6ae2f62b263a3e10e4f31b94bd751c1d03.0
  # or 
  yarn add @opencreek/ext@1.5.1--canary.8.9991fa6ae2f62b263a3e10e4f31b94bd751c1d03.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
