### PR TITLE
Allow flattening of Chain<Array<T>> into Chain<T>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "prettier": "^2.4.1",
-        "typescript": "^4.4.3"
+        "typescript": "5.1.6"
       }
     },
     "node_modules/@auto-it/bot-list": {
@@ -4833,16 +4833,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-memoize": {
@@ -8666,9 +8666,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true
     },
     "typescript-memoize": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "prettier": "^2.4.1",
-    "typescript": "^4.4.3"
+    "typescript": "5.1.6"
   },
   "prettier": {
     "semi": false

--- a/src/collections.test.ts
+++ b/src/collections.test.ts
@@ -128,6 +128,14 @@ test("should allow flattening on Chain<Array<T>>", (t) => {
   const arr = [[1], [2, 3]]
   const result = chain(arr).flatten().writableValue()
 
-  t.is(result.length, 3)
   t.deepEqual(result, [1, 2, 3])
+})
+
+test("should allow flattening on mixed Chains", (t) => {
+  const arr = [[1], /* chain([2, 3]), 4, */ [{ foo: 5 }]]
+  const chainIn = chain(arr)
+  const flattened = chainIn.flatten()
+  const result = flattened.writableValue()
+
+  t.deepEqual(result, [1, 2, 3, 4, { foo: 5 }])
 })

--- a/src/collections.test.ts
+++ b/src/collections.test.ts
@@ -132,7 +132,7 @@ test("should allow flattening on Chain<Array<T>>", (t) => {
 })
 
 test("should allow flattening on mixed Chains", (t) => {
-  const arr = [[1], /* chain([2, 3]), 4, */ [{ foo: 5 }]]
+  const arr = [[1], chain([2, 3]), 4, { foo: 5 }]
   const chainIn = chain(arr)
   const flattened = chainIn.flatten()
   const result = flattened.writableValue()

--- a/src/collections.test.ts
+++ b/src/collections.test.ts
@@ -123,3 +123,11 @@ test("should minOf correctly", async (t) => {
     undefined
   )
 })
+
+test("should allow flattening on Chain<Array<T>>", (t) => {
+  const arr = [[1], [2, 3]]
+  const result = chain(arr).flatten().writableValue()
+
+  t.is(result.length, 3)
+  t.deepEqual(result, [1, 2, 3])
+})


### PR DESCRIPTION
All of the whitespace changes come from `lint:fix` ¯\_(ツ)_/¯ 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.1--canary.25.5748379176.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/ext@2.0.1--canary.25.5748379176.0
  # or 
  yarn add @opencreek/ext@2.0.1--canary.25.5748379176.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
