### PR TITLE
Rename `distinctAsSet` to `toSet` and add the ability to return Sets in flatMap

### DIFF
--- a/src/collections.test.ts
+++ b/src/collections.test.ts
@@ -139,3 +139,26 @@ test("should allow flattening on mixed Chains", (t) => {
 
   t.deepEqual(result, [1, 2, 3, 4, { foo: 5 }])
 })
+
+test("should correctly create a set", (t) => {
+  const arr = [1, 2, 3, 2, 1, 3]
+  const set = chain(arr).toSet()
+
+  t.is(set.size, 3)
+  t.is(set.has(1), true)
+  t.is(set.has(2), true)
+  t.is(set.has(3), true)
+})
+
+test("should allow flatMap over sets", (t) => {
+  const arr = [
+    [1, 1],
+    [2, 3, 2, 3, 1],
+  ]
+
+  const result = chain(arr)
+    .flatMap((it) => new Set(it))
+    .value()
+
+  t.deepEqual(result, [1, 2, 3, 1])
+})

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -177,7 +177,7 @@ export class ObjectChain<K extends string | number | symbol, T> {
 export class Chain<T> {
   constructor(private val: ReadonlyArray<T>) {}
 
-  distinctAsSet(): Set<T> {
+  toSet(): Set<T> {
     return new Set(this.val)
   }
 
@@ -339,11 +339,12 @@ export class Chain<T> {
       el: T,
       index: number,
       array: ReadonlyArray<T>,
-    ) => Chain<U> | ReadonlyArray<U>,
+    ) => Chain<U> | ReadonlyArray<U> | Set<U>,
   ): Chain<U> {
     const ret = this.val.flatMap((el, index, arr) => {
       const mapped = transformer(el, index, arr)
       if (mapped instanceof Chain) return mapped.value()
+      if (mapped instanceof Set) return [...mapped]
       return mapped
     })
     return new Chain(ret)


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.0--canary.28.5823054779.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/ext@2.3.0--canary.28.5823054779.0
  # or 
  yarn add @opencreek/ext@2.3.0--canary.28.5823054779.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
