### PR TITLE
Fix compact display notations showing decimal parts

### DIFF
--- a/src/BigDecimal.test.ts
+++ b/src/BigDecimal.test.ts
@@ -582,6 +582,12 @@ test("BigDecimal format", (t) => {
     currency: "USD",
     style: "currency",
   })
+  const shortEnFormatter = new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    style: "currency",
+    notation: "compact",
+    compactDisplay: "short",
+  })
   const deFormatter = new Intl.NumberFormat("de-DE", {
     currency: "EUR",
     style: "currency",
@@ -614,4 +620,6 @@ test("BigDecimal format", (t) => {
     ).format(jpFormatter),
     "￥172,584,172,487,128,471,827,481,274,812,748,172,482,173,817,264,578,623,174,671,127,348,912,478,127,481,274",
   )
+
+  t.is(new BigDecimal("12345.67").format(shortEnFormatter), "$12K")
 })

--- a/src/BigDecimal.ts
+++ b/src/BigDecimal.ts
@@ -305,9 +305,17 @@ export class BigDecimal {
     // @ts-expect-error formatToParts does accept string parameters for formatting, even if the types don't know that
     const decimalParts = formatter.formatToParts(decimalNumber.toString())
 
+    const isCompactDisplay = integerParts.some((it) => it.type === "compact")
+
     const partsBeforeDecimal = chain(integerParts)
       .takeWhile((part) => part.type !== "decimal")
       .value()
+
+    if (isCompactDisplay) {
+      // if we find a compact display notation, we assume you don't want to see the decimal part
+      return partsBeforeDecimal.map((it) => it.value).join("")
+    }
+
     const partsAfterDecimal = chain(decimalParts)
       .dropWhile((part) => part.type !== "decimal")
       .value()


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.7.1--canary.34.6851119051.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/ext@2.7.1--canary.34.6851119051.0
  # or 
  yarn add @opencreek/ext@2.7.1--canary.34.6851119051.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
